### PR TITLE
Use CameraDevice constant for still capture template

### DIFF
--- a/app/src/main/java/com/sandyz/virtualcam/hooks/VirtualCameraUniversal.kt
+++ b/app/src/main/java/com/sandyz/virtualcam/hooks/VirtualCameraUniversal.kt
@@ -256,7 +256,7 @@ class VirtualCameraUniversal : IHook {
                             val template = param.args[0] as? Int ?: return
                             val builder = param.result ?: return
                             builderTemplates[builder] = template
-                            if (template == CaptureRequest.TEMPLATE_STILL_CAPTURE) {
+                            if (template == CameraDevice.TEMPLATE_STILL_CAPTURE) {
                                 PhotoSwapState.markStillCapture()
                             }
                             xLog("[C2] createCaptureRequest template=$template builder=$builder")


### PR DESCRIPTION
## Summary
- adjust the camera2 hook to compare still-capture templates against CameraDevice.TEMPLATE_STILL_CAPTURE

## Testing
- ./gradlew :app:assemble --console=plain *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d5dce01468832b96fd91fbece4a5af