### PR TITLE
Fix FileOutputStream hook constructors

### DIFF
--- a/app/src/main/java/com/sandyz/virtualcam/hooks/VirtualCameraUniversal.kt
+++ b/app/src/main/java/com/sandyz/virtualcam/hooks/VirtualCameraUniversal.kt
@@ -1070,8 +1070,6 @@ class VirtualCameraUniversal : IHook {
         if (!fileOutputStreamHooksInstalled.compareAndSet(false, true)) {
             return
         }
-        val className = "java.io.FileOutputStream"
-
         fun track(stream: Any, path: String?) {
             if (PhotoSwapState.isSelfCall()) return
             val actual = path ?: return
@@ -1085,7 +1083,7 @@ class VirtualCameraUniversal : IHook {
 
         try {
             XposedHelpers.findAndHookConstructor(
-                className,
+                FileOutputStream::class.java,
                 String::class.java,
                 object : XC_MethodHook() {
                     override fun afterHookedMethod(param: MethodHookParam) {
@@ -1099,7 +1097,7 @@ class VirtualCameraUniversal : IHook {
 
         try {
             XposedHelpers.findAndHookConstructor(
-                className,
+                FileOutputStream::class.java,
                 File::class.java,
                 object : XC_MethodHook() {
                     override fun afterHookedMethod(param: MethodHookParam) {
@@ -1113,7 +1111,7 @@ class VirtualCameraUniversal : IHook {
 
         try {
             XposedHelpers.findAndHookConstructor(
-                className,
+                FileOutputStream::class.java,
                 File::class.java,
                 Boolean::class.javaPrimitiveType,
                 object : XC_MethodHook() {
@@ -1128,8 +1126,7 @@ class VirtualCameraUniversal : IHook {
 
         try {
             XposedHelpers.findAndHookMethod(
-                className,
-                null,
+                FileOutputStream::class.java,
                 "close",
                 object : XC_MethodHook() {
                     override fun afterHookedMethod(param: MethodHookParam) {


### PR DESCRIPTION
## Summary
- update FileOutputStream hook constructor registrations to use the class-based overloads
- align the close hook with the same class reference to avoid relying on string-based lookup

## Testing
- `./gradlew assembleDebug` *(fails: Unsupported class file major version 65 while running Gradle with the bundled JDK)*

------
https://chatgpt.com/codex/tasks/task_b_68d5de94471c832b8a977a69007c6078